### PR TITLE
Update libigraph apt package names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Dependencies in Fedora/RedHat:
 
 Dependencies in Ubuntu/Debian:
 
-    sudo apt-get install cmake libglib2.0-0 libglib2.0-dev libigraph0v5 libigraph0-dev
+    sudo apt-get install cmake libglib2.0-0 libglib2.0-dev libigraph1 libigraph-dev
 
 Build with a custom install prefix:
 


### PR DESCRIPTION
On Debian 11, libigraph0*-packages are no longer available.   
However, libigraph1 and libigraph-dev worked fine on my Debian 11 system.