### PR TITLE
Update payload size for a full packet

### DIFF
--- a/src/tgen-markovmodel.h
+++ b/src/tgen-markovmodel.h
@@ -8,7 +8,7 @@
 #include <glib.h>
 
 /* this is how many bytes we send for each packet type observation */
-#define TGEN_MMODEL_PACKET_DATA_SIZE 1434
+#define TGEN_MMODEL_PACKET_DATA_SIZE 1460
 /* and packets sent within this many microseconds will be sent
  * at the same time for efficiency reasons */
 #define TGEN_MMODEL_MICROS_AT_ONCE 10000


### PR DESCRIPTION
An MTU of 1500 bytes with IP and TCP headers of 20 bytes each
results in a payload of 1460 bytes.

See shadow/shadow#1763