### PR TITLE
Get tgen working on all shadow-supported platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
 
 name: Tests
+permissions: read-all
+
+defaults:
+  run:
+    shell: bash
 
 on:
   push:
@@ -13,24 +18,90 @@ on:
       - '**.md'
       - 'LICENSE'
 
+env:
+  DEBIAN_FRONTEND: noninteractive
+
 jobs:
   testing:
     runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.container }}
     strategy:
       matrix:
         cc: ['gcc', 'clang']
+        container:
+          - 'ubuntu:18.04'
+          - 'ubuntu:20.04'
+          - 'debian:10-slim'
+          - 'debian:11-slim'
+          - 'fedora:34'
+          - 'quay.io/centos/centos:stream8'
     steps:
       - name: Update packages
-        run: sudo apt-get update
+        run: |
+          case ${{ matrix.container }} in
+            ubuntu* | debian*)
+            apt-get update
+            ;;
+          esac
 
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Install tgen dependencies
-        run: sudo apt-get install -y ${{ matrix.cc }} cmake libglib2.0-0 libglib2.0-dev libigraph0v5 libigraph0-dev
+        run: |
+          case ${{ matrix.container }} in
+            ubuntu*)
+              apt-get install -y \
+                ${{ matrix.cc }} \
+                cmake \
+                libglib2.0-0 \
+                libglib2.0-dev \
+                libigraph0v5 \
+                libigraph0-dev
+              ;;
+            debian*)
+              apt-get install -y \
+                ${{ matrix.cc }} \
+                cmake \
+                libglib2.0-0 \
+                libglib2.0-dev \
+                libigraph-dev
+              ;;
+            fedora*)
+              dnf install -y \
+                ${{ matrix.cc }} \
+                cmake \
+                glib2 \
+                glib2-devel \
+                igraph \
+                igraph-devel
+              ;;
+            *centos*stream8)
+              dnf install -y \
+                ${{ matrix.cc }} \
+                cmake \
+                glib2 \
+                glib2-devel
+              dnf install -y https://dl.fedoraproject.org/pub/archive/epel/7.7/x86_64/Packages/i/igraph-0.7.1-12.el7.x86_64.rpm
+              dnf install -y https://dl.fedoraproject.org/pub/archive/epel/7.7/x86_64/Packages/i/igraph-devel-0.7.1-12.el7.x86_64.rpm
+              ;;
+            *)
+              echo "Unhandled container ${{ matrix.container }}"
+              exit 1
+          esac
 
       - name: Build tgen
         run: mkdir -p build && cd build && CC=${{ matrix.cc }} cmake .. && make
+
+      - name: Install test dependencies
+        run: |
+          case ${{ matrix.container }} in
+            fedora* | *centos*)
+              dnf install -y \
+                diffutils
+              ;;
+          esac
 
       - name: Test mmodel
         run: bash test/run_mmodel_tests.sh
@@ -39,10 +110,65 @@ jobs:
         run: bash test/run_tgen_integration_tests.sh
 
       - name: Install tgentools dependencies
-        run: sudo apt install -y python3 python3-dev python3-pip python3-venv libxml2 libxml2-dev libxslt1.1 libxslt1-dev libpng16-16 libpng-dev libfreetype6 libfreetype6-dev libblas-dev liblapack-dev
+        run: |
+          case ${{ matrix.container }} in
+            ubuntu* | debian*)
+              apt install -y \
+                gfortran \
+                python3 \
+                python3-dev \
+                python3-pip \
+                python3-venv \
+                libjpeg-dev \
+                libxml2 \
+                libxml2-dev \
+                libxslt1.1 \
+                libxslt1-dev \
+                libpng16-16 \
+                libpng-dev \
+                libfreetype6 \
+                libfreetype6-dev \
+                libblas-dev \
+                liblapack-dev 
+              ;;
+            fedora*)
+              dnf install -y \
+                cmake \
+                glib2 \
+                glib2-devel \
+                libdeflate \
+                python3 \
+                python3-pip \
+                xz
+              pip3 install virtualenv
+              ;;
+            *centos*)
+              dnf install -y \
+                cmake \
+                glib2 \
+                glib2-devel \
+                libjpeg-turbo \
+                libjpeg-turbo-devel \
+                platform-python-devel \
+                python3 \
+                python3-pip \
+                xz \
+                zlib \
+                zlib-devel
+
+              pip3 install virtualenv
+              ;;
+            *)
+              echo "Unhandled container ${{ matrix.container }}"
+              exit 1
+          esac
 
       - name: Build tgentools
-        run: python3 -m venv build/toolsenv && source build/toolsenv/bin/activate && pip3 install -r tools/requirements.txt && pip3 install -I tools/
+        run: |
+          python3 -m venv build/toolsenv
+          source build/toolsenv/bin/activate
+          pip3 install -r tools/requirements.txt
+          pip3 install -I tools/
 
       - name: Test tgentools
         run: bash test/run_tgentools_integration_tests.sh

--- a/src/tgen-markovmodel.c
+++ b/src/tgen-markovmodel.c
@@ -92,6 +92,36 @@ struct _TGenMarkovModel {
     guint magic;
 };
 
+// igraph_i_attribute_gettype was removed from igraph in 0.9. The closest
+// replacement appears to be `igraph_cattribute_table.gettype`, though it's
+// unclear from the documentation whether it's guaranteed to be non-NULL nor
+// whether it's intended to be callable by users of the library.
+//
+// Therefore we make a best-effort to detect type mismatches, but may not
+// always be able to do so.
+static gboolean tgenmarkovmodel_attributeTypeMismatch(const igraph_t *graph, igraph_attribute_type_t desiredType,
+        igraph_attribute_elemtype_t elemtype, const char *name) {
+    if (!igraph_cattribute_table.gettype) {
+        // We don't know whether there's a type mismatch. No harm done if the
+        // types are correct, but potentially surprising behavior if they're
+        // not.
+        tgen_warning("Internal error: igraph_cattribute_table.gettype missing; unable to validate attribute types");
+        return FALSE;
+    }
+    igraph_attribute_type_t type = IGRAPH_ATTRIBUTE_DEFAULT;
+    if (igraph_cattribute_table.gettype(graph, &type, elemtype, name) != IGRAPH_SUCCESS) {
+        // The igraph documentation says it'll abort on any error, but in case
+        // it doesn't, error out here.
+        tgen_warning("igraph_cattribute_table.gettype failed; unable to validate attribute type");
+        return TRUE;
+    }
+    if (type != desiredType) {
+        tgen_warning("got type %d instead of %d for attribute '%s'", type, desiredType, name);
+        return TRUE;
+    }
+    return FALSE;
+}
+
 static const gchar* _tgenmarkovmodel_vertexAttributeToString(VertexAttribute attr) {
     if(attr == VERTEX_ATTR_ID) {
         return "name";
@@ -226,7 +256,7 @@ static gboolean _tgenmarkovmodel_vertexIDIsEmission(const gchar* idStr) {
     }
 }
 
-/* if the value is found and not NULL, it's value is returned in valueOut.
+/* if the value is found and not NULL, its value is returned in valueOut.
  * returns true if valueOut has been set, false otherwise */
 static gboolean _tgenmarkovmodel_findVertexAttributeString(TGenMarkovModel* mmodel, igraph_integer_t vertexIndex,
         VertexAttribute attr, const gchar** valueOut) {
@@ -239,16 +269,14 @@ static gboolean _tgenmarkovmodel_findVertexAttributeString(TGenMarkovModel* mmod
     const gchar* name = _tgenmarkovmodel_vertexAttributeToString(attr);
 
     if(igraph_cattribute_has_attr(mmodel->graph, IGRAPH_ATTRIBUTE_VERTEX, name)) {
-        igraph_attribute_type_t type = IGRAPH_ATTRIBUTE_DEFAULT;
-        igraph_i_attribute_gettype(mmodel->graph, &type, IGRAPH_ATTRIBUTE_VERTEX, name);
-
-        if(type == IGRAPH_ATTRIBUTE_STRING) {
-            const gchar* value = igraph_cattribute_VAS(mmodel->graph, name, vertexIndex);
-            if(value != NULL && value[0] != '\0') {
-                if(valueOut != NULL) {
-                    *valueOut = value;
-                    return TRUE;
-                }
+        if (tgenmarkovmodel_attributeTypeMismatch(mmodel->graph, IGRAPH_ATTRIBUTE_STRING, IGRAPH_ATTRIBUTE_VERTEX, name)) {
+            return FALSE;
+        }
+        const gchar* value = igraph_cattribute_VAS(mmodel->graph, name, vertexIndex);
+        if(value != NULL && value[0] != '\0') {
+            if(valueOut != NULL) {
+                *valueOut = value;
+                return TRUE;
             }
         }
     }
@@ -256,7 +284,7 @@ static gboolean _tgenmarkovmodel_findVertexAttributeString(TGenMarkovModel* mmod
     return FALSE;
 }
 
-/* if the value is found and not NULL, it's value is returned in valueOut.
+/* if the value is found and not NULL, its value is returned in valueOut.
  * returns true if valueOut has been set, false otherwise */
 static gboolean _tgenmarkovmodel_findEdgeAttributeDouble(TGenMarkovModel* mmodel, igraph_integer_t edgeIndex,
         EdgeAttribute attr, gdouble* valueOut) {
@@ -265,25 +293,22 @@ static gboolean _tgenmarkovmodel_findEdgeAttributeDouble(TGenMarkovModel* mmodel
     const gchar* name = _tgenmarkovmodel_edgeAttributeToString(attr);
 
     if(igraph_cattribute_has_attr(mmodel->graph, IGRAPH_ATTRIBUTE_EDGE, name)) {
-        igraph_attribute_type_t type = IGRAPH_ATTRIBUTE_DEFAULT;
-        igraph_i_attribute_gettype(mmodel->graph, &type, IGRAPH_ATTRIBUTE_EDGE, name);
-
-        if(type == IGRAPH_ATTRIBUTE_NUMERIC) {
-            gdouble value = (gdouble) igraph_cattribute_EAN(mmodel->graph, name, edgeIndex);
-            if(isnan(value) == 0) {
-                if(valueOut != NULL) {
-                    *valueOut = value;
-                    return TRUE;
-                }
+        if (tgenmarkovmodel_attributeTypeMismatch(mmodel->graph, IGRAPH_ATTRIBUTE_NUMERIC, IGRAPH_ATTRIBUTE_EDGE, name)) {
+            return FALSE;
+        }
+        gdouble value = (gdouble) igraph_cattribute_EAN(mmodel->graph, name, edgeIndex);
+        if(isnan(value) == 0) {
+            if(valueOut != NULL) {
+                *valueOut = value;
+                return TRUE;
             }
         }
-
     }
 
     return FALSE;
 }
 
-/* if the value is found and not NULL, it's value is returned in valueOut.
+/* if the value is found and not NULL, its value is returned in valueOut.
  * returns true if valueOut has been set, false otherwise */
 static gboolean _tgenmarkovmodel_findEdgeAttributeString(TGenMarkovModel* mmodel, igraph_integer_t edgeIndex,
         EdgeAttribute attr, const gchar** valueOut) {
@@ -296,16 +321,14 @@ static gboolean _tgenmarkovmodel_findEdgeAttributeString(TGenMarkovModel* mmodel
     const gchar* name = _tgenmarkovmodel_edgeAttributeToString(attr);
 
     if(igraph_cattribute_has_attr(mmodel->graph, IGRAPH_ATTRIBUTE_EDGE, name)) {
-        igraph_attribute_type_t type = IGRAPH_ATTRIBUTE_DEFAULT;
-        igraph_i_attribute_gettype(mmodel->graph, &type, IGRAPH_ATTRIBUTE_EDGE, name);
-
-        if(type == IGRAPH_ATTRIBUTE_STRING) {
-            const gchar* value = igraph_cattribute_EAS(mmodel->graph, name, edgeIndex);
-            if(value != NULL && value[0] != '\0') {
-                if(valueOut != NULL) {
-                    *valueOut = value;
-                    return TRUE;
-                }
+        if (tgenmarkovmodel_attributeTypeMismatch(mmodel->graph, IGRAPH_ATTRIBUTE_STRING, IGRAPH_ATTRIBUTE_EDGE, name)) {
+            return FALSE;
+        }
+        const gchar* value = igraph_cattribute_EAS(mmodel->graph, name, edgeIndex);
+        if(value != NULL && value[0] != '\0') {
+            if(valueOut != NULL) {
+                *valueOut = value;
+                return TRUE;
             }
         }
     }


### PR DESCRIPTION
Adds a platform matrix to the CI that tests the same set of platforms as in Shadow.

Fixes the build for igraph 0.9+, which is the default on fedora:34