### PR TITLE
Add a tgen nix Flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,3 +176,25 @@ jobs:
 
       - name: Test tgentools
         run: bash test/run_tgentools_integration_tests.sh
+
+  test-nix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v15
+
+      # Not strictly required as a separate step, since `check` already builds
+      # if needed. Might be easier to debug as a distinct step, though.
+      - name: Build tgen
+        run: nix --print-build-logs build .#tgen
+
+      # Not strictly required as a separate step, since `check` already builds
+      # if needed. Might be easier to debug as a distinct step, though.
+      - name: Build tgentools
+        run: nix --print-build-logs build .#tgentools
+
+      - name: Test
+        run: nix --print-build-logs flake check

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1638887115,
+        "narHash": "sha256-emjtIeqyJ84Eb3X7APJruTrwcfnHQKs55XGljj62prs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1bd4bbd49bef217a3d1adea43498270d6e779d65",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,103 @@
+# This is a nix flake. See https://nixos.wiki/wiki/Flakes
+#
+# nix support is currently experimental.
+{
+  description = "tgen: traffic generator";
+
+  inputs = rec {
+    # Specify the (currently) latest release tag.
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-21.11";
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        version = "1.0.0";
+      in rec {
+        packages = flake-utils.lib.flattenTree rec {
+          tgen = pkgs.stdenv.mkDerivation {
+            pname = "tgen";
+            version = "${version}";
+            src = self;
+
+            buildInputs = with pkgs; [
+              cmake
+              glib
+              igraph
+              pkg-config
+            ];
+          };
+          # TODO: use pkgs.poetry2nix to avoid having to duplicate python
+          # package requirements here.  For some reason adding a pyproject.toml
+          # (required by poetry) breaks the non-nix workflow.
+          tgentools = pkgs.python3.pkgs.buildPythonApplication {
+            pname = "tgentools";
+            version = "${version}";
+            src = "${self}/tools";
+            propagatedBuildInputs = [
+              (pkgs.python3.withPackages (pythonPackages: with pythonPackages; [
+                matplotlib
+                networkx
+                numpy
+                scipy
+              ]))
+            ];
+          };
+        };
+        defaultPackage = packages.tgen;
+
+        apps.tgen = flake-utils.lib.mkApp { drv = packages.tgen; };
+        apps.tgentools = flake-utils.lib.mkApp { drv = packages.tgentools; };
+        defaultApp = apps.tgen;
+
+        checks.all = pkgs.stdenv.mkDerivation rec {
+          name = "tgen-test";
+          src = self;
+
+          tgen = packages.tgen;
+          tgentools = packages.tgentools;
+
+          # We need tgen's build inputs again to build the test binary, in
+          # addition to tgen and tgentools themselves. We also need the tgen
+          # build inputs again for the configure step, which runs cmake.
+          #
+          # XXX: Ideally our CMakeLists would be more modular s.t. we didn't
+          # need tgen's build requirements here, since we're not building it
+          # again.
+          buildInputs = packages.tgen.buildInputs ++ [
+            tgen
+            tgentools
+            pkgs.bash
+            pkgs.gnugrep
+            pkgs.diffutils
+            pkgs.coreutils
+          ];
+          buildPhase = ''
+            echo 'Building test binary'
+            (cd test && make)
+
+            # Go back to root of build dir
+            cd ..
+
+            echo 'Running mmodel tests'
+            bash test/run_mmodel_tests.sh
+
+            echo 'Running tgen integration tests'
+            bash test/run_tgen_integration_tests.sh --tgen $tgen/bin/tgen
+
+            # Ideally this would be a separate check for the tgentools
+            # package. Currently this script relies on output from
+            # test/run_tgen_integration_tests.sh though, so it'll take some
+            # work to separate them.
+            echo 'Running tgentools integration tests'
+            bash test/run_tgentools_integration_tests.sh --tgentools $tgentools/bin/tgentools
+          '';
+          # Need to create output directory to satisfy nix.
+          installPhase = "mkdir -p $out";
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,26 @@
 # This is a nix flake. See https://nixos.wiki/wiki/Flakes
 #
-# nix support is currently experimental.
+# Use with caution - nix support is experimental and may be removed without
+# warning.
+#
+# Maintainer notes:
+#
+# Some tasks that we ought to automate if we support nix in the long term, but
+# are manual for now:
+#
+#  * Version is currently hard-coded, and should be updated below
+#    when the version number changes.
+#  * We might want to occasionally bump to the latest versions in the current
+#    release, using `nix flake update`.
+#
+# Other notes:
+#  * We might want to occasionally bump the nixpkgs to the latest release
+#    branch.  If we create flakes for other shadow projects, we should probably
+#    try to keep them on the same nix release so that they can share
+#    dependencies.
+#  * This is currently tested in the github CI, so can mostly be ignored unless
+#    it breaks. A likely cause of breakage is adding a new dependency without
+#    adding it to the dependencies here.
 {
   description = "tgen: traffic generator";
 

--- a/test/run_tgen_integration_tests.sh
+++ b/test/run_tgen_integration_tests.sh
@@ -4,11 +4,21 @@
 
 set -euo pipefail
 
-./build/src/tgen resource/server.tgenrc.graphml > build/tgen.server.log &
+# Allow TGEN to optionally be specified by caller. If it isn't,
+# then assume it's in ./build/src/tgen.
+TGEN=./build/src/tgen
+while [[ ${1:-} ]]; do
+  case "$1" in
+    --tgen ) TGEN="$2"; shift 2 ;;
+    * ) echo Unrecognized arg $1; exit 1; break ;;
+  esac
+done
+
+$TGEN resource/server.tgenrc.graphml > build/tgen.server.log &
 server_pid=$!
 
-./build/src/tgen resource/client-singlefile.tgenrc.graphml > build/tgen.client-singlefile.log
-./build/src/tgen resource/client-web.tgenrc.graphml > build/tgen.client-web.log
+$TGEN resource/client-singlefile.tgenrc.graphml | tee build/tgen.client-singlefile.log
+$TGEN resource/client-web.tgenrc.graphml | tee build/tgen.client-web.log
 
 kill -9 ${server_pid}
 

--- a/test/run_tgentools_integration_tests.sh
+++ b/test/run_tgentools_integration_tests.sh
@@ -1,17 +1,30 @@
 #!/bin/bash
 
 # run from base tgen directory
+
 # tgentools must have already been installed in a virtual environment
-# in build/toolsenv
+# in build/toolsenv, or passed in via --tgentools.
 
-source build/toolsenv/bin/activate
+TGENTOOLS=
+while [[ ${1:-} ]]; do
+  case "$1" in
+    --tgentools ) TGENTOOLS="$2"; shift 2 ;;
+    * ) echo Unrecognized arg $1; exit 1; break ;;
+  esac
+done
 
-# must set these options *after* sourcing the above environment
+if [ ! "$TGENTOOLS" ]
+then
+  source build/toolsenv/bin/activate
+  TGENTOOLS=$(command -v tgentools)
+fi
+
+# Run after build/toolsenv/bin/activate, which this breaks.
 set -euo pipefail
 
 fail=0
 
-tgentools parse -p build build/tgen.client-web.log
+$TGENTOOLS parse -p build build/tgen.client-web.log
 error=$?
 
 if [ $error -eq 0 ]
@@ -22,7 +35,7 @@ else
    fail=1
 fi
 
-tgentools plot --counter-cdfs --prefix build/test -d build/tgen.analysis.json.xz test
+$TGENTOOLS plot --counter-cdfs --prefix build/test -d build/tgen.analysis.json.xz test
 error=$?
 
 if [ $error -eq 0 ]


### PR DESCRIPTION
This is mostly useful when using tgen as part of a larger nix configuration, e.g. to specify a reproducible environment for an experiment.

It can also be used to install tgen using the nix package manager. e.g. once merged, a user with the nix package manager installed could use: `nix profile install github:shadow/tgen`. (`nix profile install github:sporksmith/tgen/flake` should already work now)