### PR TITLE
Upgrade pip before installing python requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,10 @@ jobs:
         run: |
           python3 -m venv build/toolsenv
           source build/toolsenv/bin/activate
+          # Drastically improves time to install requirements on platforms with
+          # older pip in system backages, such as debian-10.
+          pip3 install --upgrade pip
+
           pip3 install -r tools/requirements.txt
           pip3 install -I tools/
 


### PR DESCRIPTION
This drastically improves the time to install python requirements on
debian:10.

22m59s before: https://github.com/shadow/tgen/runs/4485955730?check_suite_focus=true
2m36s after: https://github.com/shadow/tgen/runs/4486322368?check_suite_focus=true

I *think* the newer version of pip pulls pre-built binaries from a global cache instead of rebuilding locally.