### PR TITLE
Allow current host in peers

### DIFF
--- a/src/tgen-optionparser.c
+++ b/src/tgen-optionparser.c
@@ -89,14 +89,6 @@ GError* tgenoptionparser_parsePeer(const gchar* attributeName,
             return error;
         }
 
-        /* dont add my own address to the server pool */
-        char myname[128];
-        if (!tgenconfig_gethostname(&myname[0], 128)
-                && !g_ascii_strcasecmp(myname, tokens[0])) {
-            tgen_info("refusing to place my address in server pool for attribute '%s'", attributeName);
-            return NULL;
-        }
-
         gchar* name = tokens[0];
         in_port_t port = 0;
         guint64 portNum = g_ascii_strtoull(tokens[1], NULL, 10);


### PR DESCRIPTION
There are legitimate cases where one might want to use the current host
in "peers". In particular our tests do this by using "localhost"; this
*usually* works because the hostname returned by `gethostname` is the
~unique name of the host, so doesn't match "localhost".

In some environments, though, `gethostname` can return "localhost",
which causes the peer to get filtered out. Notably this includes nix
build environments, which intentionally avoid letting global unique
state into the environment, since it would make the build
non-reproducible.

---

I'm not sure what problem this check was originally trying to solve. If we want to keep the safeguard some alternative options are:

* Whitelist "localhost" in this check, since it's pretty clear in that case the intent is to connect to the current host. That'd fix the immediate issue under nix, though could leave this as potentially surprising behavior for future users.
* Add a command-line option to enable or disable this filtering behavior. The main place I could imagine wanting it is setting up some p2p configuration where several hosts share a list of hosts that they want to connect to, minus the current host. If that's the intent, maybe it'd be better for the command-line option to specify a hostname to filter, since the name returned by `gethostname` could a different name for the host than used in the config.