### PR TITLE
Disable CI workflow path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ on:
       - '**.md'
       - 'LICENSE'
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE'
 
 env:
   DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
The repository has required workflow jobs, so we can never skip the workflow for PRs.