### PR TITLE
Avoid using fixed-seed prng

### DIFF
--- a/src/tgen-main.c
+++ b/src/tgen-main.c
@@ -27,6 +27,12 @@ static gint _tgenmain_returnError(gint flushLogCache) {
 }
 
 static gint _tgenmain_run(gint argc, gchar *argv[]) {
+    /* We generally use glib's random number generation, but in the past subtle
+     * bugs have snuck in from using libc's random number generation without
+     * seeding it. Defensively seed it here. (glib's is always seeded from an
+     * appropriate source of entropy) */
+    srand(g_random_int());
+
     /* get our hostname for logging */
     gchar hostname[128] = {0};
     tgenconfig_gethostname(hostname, 128);

--- a/src/tgen-pool.c
+++ b/src/tgen-pool.c
@@ -61,6 +61,6 @@ void tgenpool_add(TGenPool* pool, gpointer item) {
 gpointer tgenpool_getRandom(TGenPool* pool) {
     TGEN_ASSERT(pool);
     gint numNodes = g_tree_nnodes(pool->items);
-    gint position = (numNodes > 1) ? ((gint)(rand() % numNodes)) : 0;
+    gint position = (numNodes > 1) ? ((gint)(g_random_int() % numNodes)) : 0;
     return g_tree_lookup(pool->items, &position);
 }

--- a/src/tgen-stream.c
+++ b/src/tgen-stream.c
@@ -1097,8 +1097,8 @@ static void _tgenstream_onReadable(TGenStream* stream) {
 }
 
 static GString* _tgenstream_getRandomString(gsize size) {
-    /* call rand() once to limit overhead */
-    gint r = rand() % 26;
+    /* call once to limit overhead */
+    gint r = g_random_int() % 26;
     gchar c = (gchar)('a' + r);
     /* fill the buffer. this was more efficient than malloc/memset and then g_string_new  */
     GString* buffer = g_string_new_len(NULL, (gssize)size);


### PR DESCRIPTION
libc's `rand` is seeded with `1` unless otherwise seeded with `srand`.
In particular this was causing all tgen clients with the same peer list
to choose peers in the same order.