### PR TITLE
Fix CI dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,16 +69,13 @@ jobs:
               dnf install -y \
                 ${{ matrix.cc }} \
                 cmake \
-                glib2 \
                 glib2-devel \
-                igraph \
                 igraph-devel
               ;;
             *centos*stream8)
               dnf install -y \
                 ${{ matrix.cc }} \
                 cmake \
-                glib2 \
                 glib2-devel
               dnf install -y https://dl.fedoraproject.org/pub/archive/epel/7.7/x86_64/Packages/i/igraph-0.7.1-12.el7.x86_64.rpm
               dnf install -y https://dl.fedoraproject.org/pub/archive/epel/7.7/x86_64/Packages/i/igraph-devel-0.7.1-12.el7.x86_64.rpm
@@ -131,7 +128,6 @@ jobs:
             fedora*)
               dnf install -y \
                 cmake \
-                glib2 \
                 glib2-devel \
                 libdeflate \
                 python3 \
@@ -142,15 +138,12 @@ jobs:
             *centos*)
               dnf install -y \
                 cmake \
-                glib2 \
                 glib2-devel \
-                libjpeg-turbo \
                 libjpeg-turbo-devel \
                 platform-python-devel \
                 python3 \
                 python3-pip \
                 xz \
-                zlib \
                 zlib-devel
 
               pip3 install virtualenv


### PR DESCRIPTION
When installing both zlib and zlib-devel, dnf thinks that we want the best possible version of both packages. This is a problem if the best versions of zlib and zlib-devel are incompatible (centos has fixed a security vulnerability in zlib but didn't bother updating zlib-devel). Instead, we should install the best version of zlib-devel, and use whatever zlib version is compatible with that. Also removed some other packages where we also specify devel versions.