### PR TITLE
minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,19 @@ and to monitor Tor performance in [OnionPerf](https://gitweb.torproject.org/onio
 
 ## Setup
 
+Dependencies:
+
+- CMake
+- GLib 2.0
+- IGraph
+
 Dependencies in Fedora/RedHat:
 
-    sudo yum install cmake glib2 glib2-devel igraph igraph-devel
+    sudo yum install cmake glib2-devel igraph-devel
 
 Dependencies in Ubuntu/Debian:
 
-    sudo apt-get install cmake libglib2.0-0 libglib2.0-dev libigraph-dev
+    sudo apt-get install cmake libglib2.0-dev libigraph-dev
 
 Build with a custom install prefix:
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Dependencies in Fedora/RedHat:
 
 Dependencies in Ubuntu/Debian:
 
-    sudo apt-get install cmake libglib2.0-0 libglib2.0-dev libigraph1 libigraph-dev
+    sudo apt-get install cmake libglib2.0-0 libglib2.0-dev libigraph-dev
 
 Build with a custom install prefix:
 

--- a/test/test-markovmodel.c
+++ b/test/test-markovmodel.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <stdint.h>
 
 #include <glib.h>


### PR DESCRIPTION
Adds <stdlib.h> to markov model test file.

Removes libigraph1 from the list of dependencies. I think this can be removed safely, as libigraph-dev should already include the right binaries.