### PR TITLE
Add graceful shutdowns for fixed-size streams

### DIFF
--- a/src/tgen-server.c
+++ b/src/tgen-server.c
@@ -73,8 +73,9 @@ TGenIOResponse tgenserver_onEvent(TGenServer* server, gint descriptor, TGenEvent
     g_assert((events & TGEN_EVENT_READ) && descriptor == server->socketD);
 
     gboolean blocked = FALSE;
+#ifdef DEBUG
     gint acceptedCount = 0;
-
+#endif
     /* accept as many connections as we have available, until we get EWOULDBLOCK error */
     while(!blocked) {
         gint result = _tgenserver_acceptPeer(server);
@@ -86,7 +87,9 @@ TGenIOResponse tgenserver_onEvent(TGenServer* server, gint descriptor, TGenEvent
                         server->socketD, result, errno, g_strerror(errno));
             }
         } else {
+#ifdef DEBUG
             acceptedCount++;
+#endif
         }
     }
 

--- a/test/test-markovmodel.c
+++ b/test/test-markovmodel.c
@@ -74,6 +74,8 @@ static void generate(TGenMarkovModel* mmodel) {
             }
         }
     }
+
+    tgen_info("%d server packets and %d origin packets", numServerPackets, numOriginPackets);
 }
 
 gint main(gint argc, gchar *argv[]) {


### PR DESCRIPTION
For fixed-size streams where we know in advance what the send or recv length is going to be, we can do a graceful shutdown by sending application-layer FINs after we have read everything that the other side sent us. This helps ensure we don't close sockets before the data was actually received by the other end and lose data.

For non-fixed-sized streams that are driven only by a Markov model, the graceful shutdown procedure is skipped since the other end does not know when to expect the stream to end and where to look for the footer that contains the FIN.