### PR TITLE
Specify igraph < 0.10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,12 @@ include(FindPkgConfig)
 find_package(RT REQUIRED)
 find_package(M REQUIRED)
 
-pkg_check_modules(IGRAPH REQUIRED igraph)
+# We don't yet support igraph 0.10.0+, which has some API changes.
+# See https://github.com/shadow/tgen/issues/44
+#
+# Older versions of cmake don't support the `<` operator here; only `<=`.
+pkg_check_modules(IGRAPH REQUIRED igraph<=0.9.9999)
+
 pkg_check_modules(GLIB REQUIRED glib-2.0)
 
 ## Parse out igraph version. Needed to work around breaking API changes in igraph.


### PR DESCRIPTION
igraph 0.10.0 has some API changes that we don't handle. We may be able to support it through some #ifdef macros, as we already do for 0.9.x, though the devs suggest this might be painful.

For now, having cmake bail out and explain that the igraph version is incompatible is better than having a bunch of compiler errors.

See https://github.com/shadow/tgen/issues/44