### PR TITLE
Fix build for igraph v0.10.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,24 +36,6 @@ jobs:
           - 'debian:12-slim'
           - 'fedora:37'
     steps:
-      # See https://github.com/shadow/tgen/issues/44#issuecomment-1693982909
-      - name: Install debian:11 backports
-        if: ${{ matrix.container == 'debian:12-slim' }}
-        run: |
-          cat <<EOF > /etc/apt/sources.list.d/bullseye.sources
-          Types: deb
-          URIs: http://deb.debian.org/debian
-          Suites: bullseye bullseye-updates
-          Components: main
-          Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
-
-          Types: deb
-          URIs: http://deb.debian.org/debian-security
-          Suites: bullseye-security
-          Components: main
-          Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
-          EOF
-
       - name: Update packages
         run: |
           case ${{ matrix.container }} in
@@ -74,14 +56,6 @@ jobs:
                 cmake \
                 libglib2.0-dev \
                 libigraph-dev
-              ;;
-            debian:12*)
-              # See https://github.com/shadow/tgen/issues/44#issuecomment-1693982909
-              apt-get install -y \
-                ${{ matrix.cc }} \
-                cmake \
-                libglib2.0-dev \
-                libigraph-dev/bullseye
               ;;
             debian*)
               apt-get install -y \
@@ -175,7 +149,7 @@ jobs:
           python3 -m venv build/toolsenv
           source build/toolsenv/bin/activate
           # Drastically improves time to install requirements on platforms with
-          # older pip in system backages, such as debian-10.
+          # older pip in system packages, such as debian-10.
           pip3 install --upgrade pip
 
           pip3 install -r tools/requirements.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,7 @@ include(FindPkgConfig)
 find_package(RT REQUIRED)
 find_package(M REQUIRED)
 
-# We don't yet support igraph 0.10.0+, which has some API changes.
-# See https://github.com/shadow/tgen/issues/44
-#
-# Older versions of cmake don't support the `<` operator here; only `<=`.
-pkg_check_modules(IGRAPH REQUIRED igraph<=0.9.9999)
-
+pkg_check_modules(IGRAPH REQUIRED igraph)
 pkg_check_modules(GLIB REQUIRED glib-2.0)
 
 ## Parse out igraph version. Needed to work around breaking API changes in igraph.

--- a/src/tgen-graph.c
+++ b/src/tgen-graph.c
@@ -1272,9 +1272,6 @@ TGenGraph* tgengraph_new(gchar* path) {
          * from multiple threads at the same time. this is not a problem when shadow
          * uses dlmopen to get a private namespace for each plugin. */
 
-        /* use the built-in C attribute handler */
-        igraph_attribute_table_t* oldHandler = igraph_set_attribute_table(&igraph_cattribute_table);
-
         g->graph = _tgengraph_loadNewGraph(g->graphPath);
         if(!g->graph) {
             error = g_error_new(G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
@@ -1291,9 +1288,6 @@ TGenGraph* tgengraph_new(gchar* path) {
         if(!error) {
             error = _tgengraph_parseGraphVertices(g);
         }
-
-        /* replace the old handler */
-        igraph_set_attribute_table(oldHandler);
     }
 
     if(error) {

--- a/src/tgen-igraph-compat.h
+++ b/src/tgen-igraph-compat.h
@@ -5,9 +5,30 @@
 #ifndef TGEN_IGRAPH_COMPAT_H_
 #define TGEN_IGRAPH_COMPAT_H_
 
-/* Renamed in in igraph 0.9.0 */
+/* Renamed in igraph 0.9.0 */
 #if IGRAPH_VERSION_MAJOR==0 && IGRAPH_VERSION_MINOR<9
 #define igraph_set_attribute_table igraph_i_set_attribute_table
+#endif
+
+/* Changed in igraph 0.10.0 */
+#if IGRAPH_VERSION_MAJOR == 0 && IGRAPH_VERSION_MINOR < 10
+// Renamed
+#define igraph_connected_components igraph_clusters
+#define IGRAPH_ATTRIBUTE_UNSPECIFIED IGRAPH_ATTRIBUTE_DEFAULT
+// Change to int types
+#define igraph_vector_int_t igraph_vector_t
+#define igraph_vector_int_init igraph_vector_init
+#define igraph_vector_int_size igraph_vector_size
+#define igraph_vector_int_get igraph_vector_e
+#define igraph_vector_int_destroy igraph_vector_destroy
+// Removed the name arg and return it instead
+inline const char *igraph_strvector_get_compat(igraph_strvector_t *sv,
+                                               igraph_integer_t idx) {
+  char *name_ = NULL;
+  (igraph_strvector_get)(sv, idx, &name_);
+  return (const char *)name_;
+}
+#define igraph_strvector_get igraph_strvector_get_compat
 #endif
 
 #endif

--- a/src/tgen-main.c
+++ b/src/tgen-main.c
@@ -10,6 +10,7 @@
 #include <igraph.h>
 
 #include "tgen.h"
+#include "tgen-igraph-compat.h"
 
 static void _tgenmain_cleanup(gint status, gpointer arg) {
     if(arg) {
@@ -81,6 +82,9 @@ static gint _tgenmain_run(gint argc, gchar *argv[]) {
     } else {
         tgen_message("Set SIG_IGN for signal SIGPIPE");
     }
+
+    /* use the built-in C attribute handler. this is set once and then left alone. */
+    igraph_set_attribute_table(&igraph_cattribute_table);
 
     /* parse the config file */
     TGenGraph* graph = tgengraph_new(argv[1]);

--- a/src/tgen-markovmodel.c
+++ b/src/tgen-markovmodel.c
@@ -109,7 +109,7 @@ static gboolean tgenmarkovmodel_attributeTypeMismatch(const igraph_t *graph, igr
         tgen_warning("Internal error: igraph_cattribute_table.gettype missing; unable to validate attribute types");
         return FALSE;
     }
-    igraph_attribute_type_t type = IGRAPH_ATTRIBUTE_DEFAULT;
+    igraph_attribute_type_t type = IGRAPH_ATTRIBUTE_UNSPECIFIED;
     if (igraph_cattribute_table.gettype(graph, &type, elemtype, name) != IGRAPH_SUCCESS) {
         // The igraph documentation says it'll abort on any error, but in case
         // it doesn't, error out here.

--- a/src/tgen-markovmodel.c
+++ b/src/tgen-markovmodel.c
@@ -880,10 +880,6 @@ static igraph_t* _tgenmarkovmodel_loadGraph(FILE* graphFileStream, const gchar* 
     rewind(graphFileStream);
 
     igraph_t* graph = g_new0(igraph_t, 1);
-
-    /* make sure we use the correct attribute handler */
-    igraph_set_attribute_table(&igraph_cattribute_table);
-
     result = igraph_read_graph_graphml(graph, graphFileStream, 0);
 
     if (result != IGRAPH_SUCCESS) {

--- a/test/test-markovmodel.c
+++ b/test/test-markovmodel.c
@@ -2,7 +2,9 @@
 #include <stdint.h>
 
 #include <glib.h>
+#include <igraph.h>
 
+#include "tgen-igraph-compat.h"
 #include "tgen-log.h"
 #include "tgen-markovmodel.h"
 
@@ -86,6 +88,9 @@ gint main(gint argc, gchar *argv[]) {
         tgen_info("USAGE: <seed> <path/to/markovmodel.graphml.xml>; e.g., 123456 traffic.packet.model.graphml.xml");
         return EXIT_FAILURE;
     }
+
+    /* use the built-in C attribute handler. this is set once and then left alone. */
+    igraph_set_attribute_table(&igraph_cattribute_table);
 
     guint32 seed = (guint32)atoi(argv[1]);
     gchar* path = g_strdup(argv[2]);


### PR DESCRIPTION
This fixes the tgen build on systems with igraph library versions >= 0.10.0. We no longer need to use workarounds to install older version from backports or previous release repositories.

The general strategy here was to implement the tgen code according to the newer igraph api changes from v0.10.x, and then set up the messy compat definitions in `tgen-igraph-compat.h` that we can eventually just delete if we ever decide we no longer want to support igraph versions older than v0.10.0.

We also stop setting the C attribute table multiple times during program execution, and just sets it once at program startup as explained in https://github.com/shadow/tgen/issues/44#issuecomment-1407073183.

Fixes #44 